### PR TITLE
CORE-10703: expanded experimental text and provided link

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -14,8 +14,12 @@ for the *Connext DDS* Getting Started Guide, User's Manual
 and the reference for the C, C++, Java, and .NET APIs.
 
 RTI also provides *RTI Connector*, a limited, simpler API for Python®
-and JavaScript. *RTI Connector* for Python is production-ready
-and easier to use, but the *Connext DDS* Python API is more extensive.
+and JavaScript. `RTI Connector for Python <https://community.rti.com/static/documentation/connector/current/api/python/index.html>`_ 
+is production-ready and easier to get started with; the experimental 
+*Connext DDS* Python API is more extensive. (The two APIs are based on 
+different technologies and do not share code. Experimental features should 
+not be used in production systems. 
+See `Experimental Features in the Connext DDS Core Libraries Release Notes <https://community.rti.com/static/documentation/connext-dds/6.0.1/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_ReleaseNotes/index.htm#ReleaseNotes/Experimental_Features.htm>`_ for more information.)
 
 This Python API is based on the Modern C++ API and is similar but has a few key
 differences.


### PR DESCRIPTION
The added link to the Connector doc uses "current" in its path, so that it will work today and in Hercules.

The added link to "Experimental Features" in the core Release Notes works today. In Hercules, we will need to update the link to use the new doc structure and the new "Experimental Features" text. The new "Experimental Features" text simply adds a statement at the end that RTI Support does not provide support for experimental features.