### PR TITLE
Feature/dynamicdata iterators

### DIFF
--- a/modules/connextdds/src/dds/core/xtypes/EnumMember.cpp
+++ b/modules/connextdds/src/dds/core/xtypes/EnumMember.cpp
@@ -68,7 +68,12 @@ void init_class_defs(py::class_<EnumMember>& cls)
                         return !(member.ordinal() == other);
                     },
                     py::is_operator(),
-                    "Test for inequality.");
+                    "Test for inequality.")
+            .def(
+                    "__str__",
+                    [](const EnumMember& e) {
+                        return e.name().to_std_string();
+                    });
 }
 
 template<>

--- a/test/python/test_complex_data.py
+++ b/test/python/test_complex_data.py
@@ -190,7 +190,7 @@ def test_documentation_examples():
             point.data["y"] = 222
     print(sample["path[2].x"]) # prints 111
 
-    with pytest.raises(dds.PreconditionNotMetError) as excinfo:
+    with pytest.raises(dds.InvalidArgumentError) as excinfo:
         sample["bad_member"] = "bad value"
     with pytest.raises(ValueError) as excinfo:
         sample["location"] = "bad value"


### PR DESCRIPTION
Getting member info from a DynamicData object via Modern C++ API required care due to possibility of field not existing. Switched to using the C implementation to work around this and simplify the logic. This also makes the DynamicData iterators more useful.