### PR TITLE
Changes to build with current connextdds develop tree.

### DIFF
--- a/modules/connextdds/src/dds/core/InstanceHandle.cpp
+++ b/modules/connextdds/src/dds/core/InstanceHandle.cpp
@@ -9,6 +9,7 @@
  * damages arising out of the use or inability to use the software.
  */
 
+#include <sstream>
 #include "PyConnext.hpp"
 #include "PySeq.hpp"
 #include "PyEntity.hpp"

--- a/modules/connextdds/src/rti/core/CoherentSetInfo.cpp
+++ b/modules/connextdds/src/rti/core/CoherentSetInfo.cpp
@@ -9,6 +9,7 @@
  * damages arising out of the use or inability to use the software.
  */
 
+#include <sstream>
 #include "PyConnext.hpp"
 #if rti_connext_version_gte(6, 1, 0)
 #include <rti/core/CoherentSetInfo.hpp>

--- a/modules/connextdds/src/rti/core/Guid.cpp
+++ b/modules/connextdds/src/rti/core/Guid.cpp
@@ -9,6 +9,8 @@
  * damages arising out of the use or inability to use the software.
  */
 
+#include <sstream>
+
 #include "PyConnext.hpp"
 #include <rti/core/Guid.hpp>
 

--- a/modules/connextdds/src/rti/core/SampleIdentity.cpp
+++ b/modules/connextdds/src/rti/core/SampleIdentity.cpp
@@ -9,6 +9,8 @@
  * damages arising out of the use or inability to use the software.
  */
 
+#include <sstream>
+
 #include "PyConnext.hpp"
 #include <rti/core/SampleIdentity.hpp>
 

--- a/resources/cmake/FindRTIConnextDDS.cmake
+++ b/resources/cmake/FindRTIConnextDDS.cmake
@@ -1586,7 +1586,7 @@ endif()
 
 # In the header files, there is a variable that contains the BUILD ID of the
 # release. From the BUILD ID, we can get the version.
-set(regex_for_build "NDDSCORE_BUILD_.*_RTI_REL")
+set(regex_for_build "NDDSCORE_BUILD_.*_RTI_.*")
 file(STRINGS
     "${CONNEXTDDS_DIR}/include/ndds/core_version/core_version_buildid.h"
     build_id_line


### PR DESCRIPTION
1) It looks like sstream was previously included indirectly and no longer is.

2) Allow FindRTIConnextDDS to build against personal builds of connextdds, not only official releases.